### PR TITLE
Removed use of macro due to non-standard use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ EXSRCS := $(shell find $(EXDIR) -name '*.c' -o -name '*.cpp')
 LIBOBJS := $(addsuffix .o, $(basename $(LIBSRCS)))
 LIBA := libpluto.a
 EXBINS := $(addsuffix .e, $(basename $(EXSRCS)))
-CFLAGS = -Wall -Wextra -Werror -O3 -DPLUTO_PIX_CHAR_OFF=10240
+CFLAGS = -Wall -Wextra -Werror -O3
 LIBCFLAGS = $(CFLAGS)
 
 .PHONY: clean

--- a/src/drw.c
+++ b/src/drw.c
@@ -131,7 +131,7 @@ void pluto_write_out()
 
         sprintf(buf, "\e[38;2;%03u;%03u;%03um", (uint8_t)tr, (uint8_t)tg, (uint8_t)tb);
         strcpy((char *)&cbuf[i * 22 + (i / _pluto_canvas.width)], buf);
-        pluto_transform_ucp(&cbuf[i * 22 + 19 + (i / _pluto_canvas.width)], PLUTO_PIX_CHAR_OFF + _pluto_canvas.bitmap[i]);
+        pluto_transform_ucp(&cbuf[i * 22 + 19 + (i / _pluto_canvas.width)], 0x2800 + (uint16_t)_pluto_canvas.bitmap[i]);
     }
     for (int i = 1; i < _pluto_canvas.height; i++)
     {

--- a/src/pluto.h
+++ b/src/pluto.h
@@ -61,10 +61,6 @@ typedef struct
 } pt_t;
 /* Origin: (0x, 0y) */
 
-#ifndef PLUTO_PIX_CHAR_OFF
-#    define PLUTO_PIX_CHAR_OFF
-#endif
-
 extern pluto_lib_t _pluto_canvas;
 /* Instance */
 


### PR DESCRIPTION
The offset will always be 0x2800 so I just have it add 0x2800 (same thing it was doing with the macro just without the unneeded macro)