### PR TITLE
fix: o4 is deprecated in clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LIBSRCS := $(shell find $(LIBSRCDIR) -name '*.c')
 EXSRCS := $(shell find $(EXDIR) -name '*.c' -o -name '*.cpp')
 LIBOBJS := $(addsuffix .o, $(basename $(LIBSRCS)))
 EXBINS := $(addsuffix .e, $(basename $(EXSRCS)))
-CFLAGS = -Wall -Wextra -Werror -O4
+CFLAGS = -Wall -Wextra -Werror -O3
 LIBCFLAGS = $(CFLAGS)
 
 .PHONY: clean


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/57838468/125047093-3efa5a00-e0bc-11eb-9369-9c69fd8f38d4.png)
